### PR TITLE
Add author and make message / timestamp optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.DS_Store
 
 storage

--- a/README.md
+++ b/README.md
@@ -60,18 +60,33 @@ doc.id
 # => 'b1ff909250a5fda83042abc86f7033f9' # randomly generated
 ```
 
-And you can also save the item
+And you can also save the item, you are required to supply an author with an optional message and timestamp paramater. For example you can do the following:
 
 ```ruby
-doc.save!(Time.now)
+doc.save!({ name: 'The Colonel', email: 'colonel@example.com' })
+```
+
+
+or using the optional parameters:
+
+```ruby
+doc.save!({ name: 'The Colonel', email: 'colonel@example.com' }, 'My save message.')
+doc.save!({ name: 'The Colonel', email: 'colonel@example.com' }, 'My save message.', Time.now)
 ```
 
 You now have an item that has a single revision in `master` state (draft). You can
-update the document's content and save again
+update the document's content and save again with or without a commit message.
 
 ```ruby
 doc.tags << "Updated"
-doc.save!(Time.now)
+doc.save!({ name: 'The Colonel', email: 'colonel@example.com' })
+```
+
+or
+
+```ruby
+doc.tags << "Updated"
+doc.save!({ name: 'The Colonel', email: 'colonel@example.com' }, 'My comment for the update.')
 ```
 
 The document now has two revisions. Every save creates a new revision. All saves
@@ -89,7 +104,7 @@ ContentItem.open('b1ff909250a5fda83042abc86f7033f9')
 Once the document is ready to be seen you can publish it
 
 ```ruby
-doc.promote!('master', 'published', 'Published the document!', Time.now)
+doc.promote!('master', 'published', { name: 'The Colonel', email: 'colonel@example.com' }, 'Published the document!')
 ```
 
 That takes the current revision of `master` and creates a `published` revision from it.

--- a/lib/colonel/content_item.rb
+++ b/lib/colonel/content_item.rb
@@ -69,12 +69,16 @@ module Colonel
 
     # Public: Save the content item and update the search index
     #
-    # timestamp - the time of the save
+    # author    - a Hash containing author attributes
+    #             :name - the name of the author
+    #             :email - the email of the author
+    # message   - message of the save (optional)
+    # timestamp - time of the save (optional), Defaults to Time.now
     #
     # Returns the sha of the newly created revision
-    def save!(timestamp)
+    def save!(author, message = '', timestamp = Time.now)
       document.content = @content.to_json
-      sha = document.save!(timestamp)
+      sha = document.save!(author, message, timestamp)
 
       index!(state: 'master', updated_at: timestamp, revision: sha)
 
@@ -139,8 +143,8 @@ module Colonel
 
     # Public: Promote the document to a new state and index the change. Other than indexing, works the same way
     # as in the Document class.
-    def promote!(from, to, message, timestamp)
-      sha = document.promote!(from, to, message, timestamp)
+    def promote!(from, to, author, message = '', timestamp = Time.now)
+      sha = document.promote!(from, to, author, message, timestamp)
 
       index!(state: to, revision: sha, updated_at: timestamp)
 

--- a/lib/colonel/version.rb
+++ b/lib/colonel/version.rb
@@ -1,3 +1,3 @@
 module Colonel
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -59,7 +59,7 @@ describe Document do
       document.stub(:repository).and_return(repo)
     end
 
-    it "should create a commit on first save" do
+    it "should create a commit on first save without a commit message" do
       repo.should_receive(:write).with("some content", :blob).and_return('abcdef')
 
       Rugged::Index.should_receive(:new).and_return index
@@ -69,8 +69,31 @@ describe Document do
 
       options = {
         tree: 'foo',
-        author: {email: 'colonel@example.com', name: 'The Colonel', time: time},
-        committer: {email: 'colonel@example.com', name: 'The Colonel', time: time},
+        author: { email: 'colonel@example.com', name: 'The Colonel', time: time },
+        committer: {email: 'colonel@example.com', name: 'The Colonel', time: time },
+        message: '',
+        parents: [],
+        update_ref: 'refs/heads/master'
+      }
+
+      Rugged::Commit.should_receive(:create).with(repo, options).and_return 'foo'
+
+      expect(document.save!({ name: 'The Colonel', email: 'colonel@example.com' }, '', time)).to eq 'foo'
+      expect(document.revision).to eq 'foo'
+    end
+
+    it "should create a commit on first save with a commit message" do
+      repo.should_receive(:write).with("some content", :blob).and_return('abcdef')
+
+      Rugged::Index.should_receive(:new).and_return index
+      index.should_receive(:add).with(path: "content", oid: 'abcdef', mode: 0100644)
+      index.should_receive(:write_tree).with(repo).and_return 'foo'
+      repo.should_receive(:empty?).and_return(true)
+
+      options = {
+        tree: 'foo',
+        author: { email: 'colonel@example.com', name: 'The Colonel', time: time },
+        committer: { email: 'colonel@example.com', name: 'The Colonel', time: time },
         message: 'save from the colonel',
         parents: [],
         update_ref: 'refs/heads/master'
@@ -78,7 +101,7 @@ describe Document do
 
       Rugged::Commit.should_receive(:create).with(repo, options).and_return 'foo'
 
-      expect(document.save!(time)).to eq 'foo'
+      expect(document.save!({ email: 'colonel@example.com', name: 'The Colonel' }, 'save from the colonel', time)).to eq 'foo'
       expect(document.revision).to eq 'foo'
     end
 
@@ -93,8 +116,8 @@ describe Document do
 
       options = {
         tree: 'foo',
-        author: {email: 'colonel@example.com', name: 'The Colonel', time: time},
-        committer: {email: 'colonel@example.com', name: 'The Colonel', time: time},
+        author: { email: 'colonel@example.com', name: 'The Colonel', time: time },
+        committer: { email: 'colonel@example.com', name: 'The Colonel', time: time },
         message: 'save from the colonel',
         parents: ['head'],
         update_ref: 'refs/heads/master'
@@ -102,7 +125,7 @@ describe Document do
 
       Rugged::Commit.should_receive(:create).with(repo, options).and_return 'foo'
 
-      expect(document.save!(time)).to eq 'foo'
+      expect(document.save!({ email: 'colonel@example.com', name: 'The Colonel' },'save from the colonel', time)).to eq 'foo'
     end
   end
 
@@ -261,8 +284,8 @@ describe Document do
 
         options = {
           tree: 'foo',
-          author: {email: 'colonel@example.com', name: 'The Colonel', time: time},
-          committer: {email: 'colonel@example.com', name: 'The Colonel', time: time},
+          author: { email: 'colonel@example.com', name: 'The Colonel', time: time },
+          committer: { email: 'colonel@example.com', name: 'The Colonel', time: time },
           message: 'preview from the colonel',
           parents: ['xyz2', 'xyz1'],
           update_ref: 'refs/heads/preview'
@@ -270,7 +293,7 @@ describe Document do
 
         Rugged::Commit.should_receive(:create).with(repo, options).and_return 'foo'
 
-        expect(document.promote!('master', 'preview', 'preview from the colonel', time)).to eq 'foo'
+        expect(document.promote!('master', 'preview', { name: 'The Colonel', email: 'colonel@example.com' }, 'preview from the colonel', time)).to eq 'foo'
       end
 
       it "should commit with parents from master and preview and create preview if it doesn't exist" do
@@ -286,8 +309,8 @@ describe Document do
 
         options = {
           tree: 'foo',
-          author: {email: 'colonel@example.com', name: 'The Colonel', time: time},
-          committer: {email: 'colonel@example.com', name: 'The Colonel', time: time},
+          author: { email: 'colonel@example.com', name: 'The Colonel', time: time },
+          committer: { email: 'colonel@example.com', name: 'The Colonel', time: time },
           message: 'preview from the colonel',
           parents: ['xyz1'],
           update_ref: 'refs/heads/preview'
@@ -295,7 +318,7 @@ describe Document do
 
         Rugged::Commit.should_receive(:create).with(repo, options).and_return 'foo'
 
-        expect(document.promote!('master', 'preview', 'preview from the colonel', time)).to eq 'foo'
+        expect(document.promote!('master', 'preview', { name: 'The Colonel', email: 'colonel@example.com' }, 'preview from the colonel', time)).to eq 'foo'
       end
     end
 


### PR DESCRIPTION
Adds ability to pass an author and an optional message and timestamp into `save!` also switched timestamp to be optional and to be the third parameter so that it is not required to be passed in.

Also bumped version number to major 0.1.0.
