### PR TITLE
Support for rugged backends configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'simplecov', :require => false, :group => :test
+gem 'rugged', git: 'git://github.com/redbadger/rugged.git', branch: 'backends-wip', submodules: true

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ And then execute:
 
 ### Dependencies
 
-The Colonel requires at least [elasticsearch](http://www.elasticsearch.org) 1.0 to work.  
+The Colonel requires at least [elasticsearch](http://www.elasticsearch.org) 1.0 to work.
 
 ## Usage
 
@@ -39,6 +39,7 @@ The `Colonel` module exposes a `config` struct for configuration options
 ```ruby
 Colonel.config.storage_path = 'tmp/colonel_storage/'
 Colonel.config.elasticsearch_host = 'elasticsearch.myapp.com:9200'
+Colonel.config.rugged_backend = backend_instance # optional, see below
 ```
 
 ### Create or open a ContenItem
@@ -196,6 +197,20 @@ class DocumentItem < Colonel::ContentItem
     }
   end
 end
+```
+
+### Alternative backends
+
+Internally, Colonel uses rugged for content item storage. Apart from the default file storage it supports
+alternative storage backends for rugged. For example, you could use [rugged-redis](http://github.com/redbadger/rugged-redis) to store to redis.
+
+To set the backend, use the configuration
+
+```ruby
+require 'rugged-redis'
+
+redis_backend = Rugged::Redis::Backend.new(host: '127.0.0.1', port: 6379, password: 'muchsecretwow')
+Colonel.config.rugged_backend = redis_backend
 ```
 
 ### Integrating with ActiveModel

--- a/colonel.gemspec
+++ b/colonel.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rugged"
   spec.add_runtime_dependency "elasticsearch", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/lib/colonel.rb
+++ b/lib/colonel.rb
@@ -11,9 +11,10 @@ module Colonel
   #
   # Colonel.config.storage_path - location to store git repo on disk
   # Colonel.config.elasticsearch_host - host for elasticsearch
+  # Colonel.config.rugged_backend - storage backend, an instance of Rugged::Backend
   #
   # Returns a config struct
   def self.config
-    @config ||= Struct.new(:storage_path, :elasticsearch_host).new('storage', 'localhost:9200')
+    @config ||= Struct.new(:storage_path, :elasticsearch_host, :rugged_backend).new('storage', 'localhost:9200', nil)
   end
 end

--- a/lib/colonel/document.rb
+++ b/lib/colonel/document.rb
@@ -177,7 +177,11 @@ module Colonel
 
     # Internal: The Rugged repository object for the given document
     def repository
-      @repo ||= Rugged::Repository.init_at(File.join(Colonel.config.storage_path, @name), :bare)
+      unless Colonel.config.rugged_backend.nil?
+        @repo ||= Rugged::Repository.init_at(File.join(Colonel.config.storage_path, @name), :bare, backend: Colonel.config.rugged_backend)
+      else
+        @repo ||= Rugged::Repository.init_at(File.join(Colonel.config.storage_path, @name), :bare)
+      end
     end
 
     # Class methods
@@ -191,7 +195,11 @@ module Colonel
       # Returns a Document instance
       def open(name, rev = nil)
         begin
-          repo = Rugged::Repository.new(File.join(Colonel.config.storage_path, name))
+          unless Colonel.config.rugged_backend.nil?
+            repo = Rugged::Repository.bare(File.join(Colonel.config.storage_path, name), backend: Colonel.config.rugged_backend)
+          else
+            repo = Rugged::Repository.bare(File.join(Colonel.config.storage_path, name))
+          end
         rescue Rugged::OSError
           return nil
         end


### PR DESCRIPTION
Add support for using different Rugged backends and specifying them in `Colonel.config`. See http://github.com/redbadger/rugged-redis for example Rugged backend implementation.
