### PR TITLE
Rename elasticsearch_host to elasticsearch_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `Colonel` module exposes a `config` struct for configuration options
 
 ```ruby
 Colonel.config.storage_path = 'tmp/colonel_storage/'
-Colonel.config.elasticsearch_host = 'elasticsearch.myapp.com:9200'
+Colonel.config.elasticsearch_uri = 'elasticsearch.myapp.com:9200'
 Colonel.config.rugged_backend = backend_instance # optional, see below
 ```
 

--- a/lib/colonel.rb
+++ b/lib/colonel.rb
@@ -10,11 +10,11 @@ module Colonel
   # Public: Sets configuration options.
   #
   # Colonel.config.storage_path - location to store git repo on disk
-  # Colonel.config.elasticsearch_host - host for elasticsearch
+  # Colonel.config.elasticsearch_uri - host for elasticsearch
   # Colonel.config.rugged_backend - storage backend, an instance of Rugged::Backend
   #
   # Returns a config struct
   def self.config
-    @config ||= Struct.new(:storage_path, :elasticsearch_host, :rugged_backend).new('storage', 'localhost:9200', nil)
+    @config ||= Struct.new(:storage_path, :elasticsearch_uri, :rugged_backend).new('storage', 'localhost:9200', nil)
   end
 end

--- a/lib/colonel/content_item.rb
+++ b/lib/colonel/content_item.rb
@@ -337,7 +337,7 @@ module Colonel
 
       # Public: The Elasticsearch client
       def es_client
-        @es_client ||= ::Elasticsearch::Client.new(host: Colonel.config.elasticsearch_host, log: false)
+        @es_client ||= ::Elasticsearch::Client.new(host: Colonel.config.elasticsearch_uri, log: false)
       end
 
       # Internal: Revision type name for elastic search.


### PR DESCRIPTION
Already done in the `redis` branch, just bringing it over in preparation to remove the redis branch in favor of backend config in `master`
