### PR TITLE
Return parents in history

### DIFF
--- a/lib/colonel/document.rb
+++ b/lib/colonel/document.rb
@@ -140,7 +140,7 @@ module Colonel
           author: commit.author,
           time: commit.time,
           type: [:orphan, :save, :promotion][commit.parents.count],
-          parents: (first_commit?(commit) ? commit.parents[1..-1] : commit.parents).map(&:oid)
+          parents: parents_hash(commit)
         }
         yield results.last if block_given?
 
@@ -276,6 +276,20 @@ module Colonel
 
     def first_commit?(commit)
       commit.parents.map(&:oid).include?(root_commit_oid)
+    end
+
+    def parents_hash(commit)
+      first, second = commit.parents.map(&:oid)
+
+      if second && first != root_commit_oid
+        {previous: first, source: second}
+      elsif second && first == root_commit_oid
+        {source: second}
+      elsif second.nil? && first != root_commit_oid
+        {previous: first}
+      else # i.e. second.nil? && firt == root_commit_oid
+        {}
+      end
     end
 
     def on_master?(commit)

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -424,9 +424,9 @@ describe Document do
       doc.history('preview') { |cmt| history << cmt}
 
       expect(history).to eq([
-        {rev: 'p3', message: 'meow', author: 'aliens', time: time, type: :save, parents: ['p2']},
-        {rev: 'p2', message: 'hey', author: 'me', time: time, type: :promotion, parents: ['p1', 'm2']},
-        {rev: 'p1', message: 'bye', author: 'you', time: time, type: :promotion, parents: ['m1']}
+        {rev: 'p3', message: 'meow', author: 'aliens', time: time, type: :save, parents: {previous: 'p2'}},
+        {rev: 'p2', message: 'hey', author: 'me', time: time, type: :promotion, parents: {previous: 'p1', source: 'm2'}},
+        {rev: 'p1', message: 'bye', author: 'you', time: time, type: :promotion, parents: {source: 'm1'}}
       ])
     end
   end


### PR DESCRIPTION
This is just a short-term fix for the larger problem - missing domain concept of a revision graph (#25).

Each revision history item has the OIDs of the parent commits as a hash with `previous` and `source` keys.
