### PR TITLE
Fix custom scope reindexing on restore (fix #51)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    colonel (0.5.4)
+    colonel (0.6.0)
       elasticsearch (~> 1.0.0)
 
 GEM

--- a/lib/colonel/document/revision.rb
+++ b/lib/colonel/document/revision.rb
@@ -41,6 +41,10 @@ module Colonel
       @origin = origin.is_a?(String) ? Revision.from_commit(@document, origin) : origin
     end
 
+    def inspect
+      "<Revision:#{id} type:#{type} previous:#{previous && previous.id} origin:#{origin && origin.id} message:#{message} author:#{author}>"
+    end
+
     # Public: id of the revision - a 40 character hexadecimal number which is the sha1 hash of the
     # underlying git commit.
     def id
@@ -188,10 +192,6 @@ module Colonel
       commit_options[:update_ref] = update_ref if update_ref
 
       @id = Rugged::Commit.create(repository, commit_options)
-    end
-
-    def inspect
-      "<Revision:#{id}>"
     end
 
     # Class methods

--- a/lib/colonel/indexer.rb
+++ b/lib/colonel/indexer.rb
@@ -30,7 +30,7 @@ module Colonel
           state = ref.name.split("/").last
           next if state == "root"
 
-          document.history.each do |r|
+          document.history(state).each do |r|
             event = {
               name: r.type,
               to: state

--- a/spec/indexer_spec.rb
+++ b/spec/indexer_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+
+describe Indexer do
+  describe "#document_commands" do
+    let :time do
+      Time.now
+    end
+
+    let :type do
+      Colonel::DocumentType.new('test-type')
+    end
+
+    describe "document with single save" do
+      let :repository do
+        refs = [
+          double(:reference, name: 'refs/heads/master'),
+          double(:reference, name: 'refs/tags/root')
+        ]
+        double(:repository, references: refs)
+      end
+
+      let :revisions do
+        {
+          'master' => Colonel::Revision.new(:doc, Colonel::Content.new({}), :author, "", time, nil)
+        }
+      end
+
+      let :document do
+        type.new({}).tap do |it|
+          allow(it).to receive(:repository).and_return(repository)
+          allow(it).to receive(:revisions).and_return(revisions)
+        end
+      end
+
+      it "produces correct index commands" do
+        cmds = Indexer.document_commands(document)
+
+        save = cmds.find {|it| it[:index][:_type] == 'test-type'}
+        save_rev = cmds.find {|it| it[:index][:_type] == 'test-type_rev'}
+
+        expect(save).not_to be_nil
+        expect(save_rev).not_to be_nil
+      end
+    end
+
+    describe "document with multiple saves" do
+      let :repository do
+        refs = [
+          double(:reference, name: 'refs/heads/master'),
+          double(:reference, name: 'refs/tags/root')
+        ]
+        double(:repository, references: refs)
+      end
+
+      let :revisions do
+        first_save = Colonel::Revision.new(:doc, Colonel::Content.new({}), :author, "", time, nil)
+
+        {
+          'master' => Colonel::Revision.new(:doc, Colonel::Content.new({}), :author, "", time, first_save)
+        }
+      end
+
+      let :document do
+        type.new({}).tap do |it|
+          allow(it).to receive(:repository).and_return(repository)
+          allow(it).to receive(:revisions).and_return(revisions)
+        end
+      end
+
+      it "produces correct index commands" do
+        cmds = Indexer.document_commands(document)
+
+        saves = cmds.select { |it| it[:index][:_type] == 'test-type' }
+        revs = cmds.select { |it| it[:index][:_type] == 'test-type_rev' }
+
+        expect(saves.count).to eq(1)
+        expect(revs.count).to eq(2)
+      end
+    end
+
+    describe "document with a save and a publish" do
+      let :repository do
+        refs = [
+          double(:reference, name: 'refs/heads/master'),
+          double(:reference, name: 'refs/heads/published'),
+          double(:reference, name: 'refs/tags/root')
+        ]
+        double(:repository, references: refs)
+      end
+
+      let :revisions do
+        first_save = Colonel::Revision.new(:doc, Colonel::Content.new({}), :author, "", time, nil)
+
+        {
+          'master' => first_save,
+          'published' => Colonel::Revision.new(:doc, Colonel::Content.new({}), :author, "", time, nil, first_save)
+        }
+      end
+
+      let :document do
+        type.new({}).tap do |it|
+          allow(it).to receive(:repository).and_return(repository)
+          allow(it).to receive(:revisions).and_return(revisions)
+        end
+      end
+
+      it "produces correct index commands" do
+        cmds = Indexer.document_commands(document)
+
+        saves = cmds.select { |it| it[:index][:_type] == 'test-type' && it[:index][:_id] =~ /-master$/ }
+        publishes = cmds.select { |it| it[:index][:_type] == 'test-type' && it[:index][:_id] =~ /-published$/ }
+        revs = cmds.select { |it| it[:index][:_type] == 'test-type_rev' }
+
+        expect(saves.count).to eq(1)
+        expect(publishes.count).to eq(1)
+        expect(revs.count).to eq(2)
+      end
+    end
+
+    describe "document with custom scopes" do
+      let :type do
+        Colonel::DocumentType.new('test-type') do
+          scope 'test-scope', on: [:promotion], to: ['published']
+        end
+      end
+
+      let :repository do
+        refs = [
+          double(:reference, name: 'refs/heads/master'),
+          double(:reference, name: 'refs/heads/published'),
+          double(:reference, name: 'refs/tags/root')
+        ]
+        double(:repository, references: refs)
+      end
+
+      let :revisions do
+        first_save = Colonel::Revision.new(:doc, Colonel::Content.new({}), :author, "", time, nil)
+
+        {
+          'master' => first_save,
+          'published' => Colonel::Revision.new(:doc, Colonel::Content.new({}), :author, "", time, nil, first_save)
+        }
+      end
+
+      let :document do
+        type.new({}).tap do |it|
+          allow(it).to receive(:repository).and_return(repository)
+          allow(it).to receive(:revisions).and_return(revisions)
+        end
+      end
+
+      it "produces correct index commands" do
+        cmds = Indexer.document_commands(document)
+
+        saves = cmds.select { |it| it[:index][:_type] == 'test-type' && it[:index][:_id] =~ /-master$/ }
+        publishes = cmds.select { |it| it[:index][:_type] == 'test-type' && it[:index][:_id] =~ /-published$/ }
+        revs = cmds.select { |it| it[:index][:_type] == 'test-type_rev' }
+        custom = cmds.select { |it| it[:index][:_type] == 'test-type_test-scope' }
+
+        expect(saves.count).to eq(1)
+        expect(publishes.count).to eq(1)
+        expect(custom.count).to eq(1)
+        expect(revs.count).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should resolve issues with restoring Colonel content from backup and losing the search indices for custom scopes.

/cc @jonsharratt 